### PR TITLE
Directory refs

### DIFF
--- a/pyccc/files/base.py
+++ b/pyccc/files/base.py
@@ -28,7 +28,7 @@ if ENCODING == 'ascii':
     ENCODING = 'utf-8'
 
 
-def get_tempfile():
+def get_tempfile(**kwargs):
     if not os.path.exists(CACHEDIR):
         if PY2:
             try:
@@ -38,7 +38,7 @@ def get_tempfile():
                     raise
         else:
             os.makedirs(CACHEDIR, exist_ok=True)
-    tmpfile = tempfile.NamedTemporaryFile(dir=CACHEDIR, delete=False)
+    tmpfile = tempfile.NamedTemporaryFile(dir=CACHEDIR, delete=False, **kwargs)
     return tmpfile
 
 

--- a/pyccc/files/directory.py
+++ b/pyccc/files/directory.py
@@ -131,6 +131,7 @@ class DockerArchive(DirectoryArchive, LazyDockerCopy):
     def __init__(self, *args, **kwargs):
         LazyDockerCopy.__init__(self, *args, **kwargs)
         self.archive_path = None
+        self.dirname = self.basename
 
     def put(self, destination):
         """ Copy the referenced directory to this path
@@ -138,10 +139,9 @@ class DockerArchive(DirectoryArchive, LazyDockerCopy):
         Args:
             destination (str): path to put this directory (which must NOT already exist)
         """
-        target = _get_target_path(destination, self.basename)
         if not self._fetched:
             self._fetch()
-        DirectoryArchive.put(self, target)
+        DirectoryArchive.put(self, destination)
 
     put.__doc__ = DirectoryArchive.put.__doc__
 

--- a/pyccc/files/directory.py
+++ b/pyccc/files/directory.py
@@ -5,15 +5,52 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+#s
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import tarfile
+import shutil
+
+from .remotefiles import LazyDockerCopy
+from .. import utils
 
 
-class LocalDirectoryReference(object):
+def _get_target_path(destination, origname):
+    """ Implements the directory/path semantics of linux mv/cp etc.
+
+    Examples:
+        >>> import os
+        >>> os.makedirs('./a')
+        >>> _get_target_path('./a', '/tmp/myfile')
+        './myfile'
+        >>> _get_target_path('./a/b', '/tmp/myfile')
+        './a/b'
+
+    Raises:
+        OSError: if neither destination NOR destination's parent exists OR it already exists
+    """
+    if os.path.exists(destination):
+        if not os.path.isdir(destination):
+            raise OSError('Cannot write to requested destination %s - file exists' % destination)
+        return os.path.join(destination, os.path.basename(origname))
+    else:
+        destdir = os.path.abspath(os.path.join(destination, os.path.pardir))
+        if not os.path.isdir(destdir):
+            raise OSError(
+                    'Cannot write to requested destination %s - parent directory does not exist' %
+                    destination)
+        return os.path.join(destination)
+
+
+class DirectoryReference(object):
+    pass
+
+
+class LocalDirectoryReference(DirectoryReference):
     """ This is a reference to a specific directory on the local filesystem.
 
     This allows entire directories to be staged into the dockerfile as input
@@ -22,5 +59,95 @@ class LocalDirectoryReference(object):
         self.localpath = localpath
 
     def put(self, destination):
-        import shutil
-        shutil.copytree(self.localpath, destination)
+        """ Copy the referenced directory to this path
+
+        The semantics of this command are similar to unix ``cp``: if ``destination``  already
+        exists, the copied directory will be put at ``[destination] // [basename(localpath)]``. If
+        it does not already exist, the directory will be renamed to this path (the parent directory
+        must exist).
+
+        Args:
+            destination (str): path to put this directory
+        """
+        target = _get_target_path(destination, self.localpath)
+        shutil.copytree(self.localpath, target)
+
+
+class DirectoryArchive(DirectoryReference):
+    """A tar (or tar.gz) archive of a directory
+
+    All files in this directory must be under a directory named "dirname". No other files
+    will be expanded
+
+    Args:
+        archive_path (str): path to the existing archive
+        dirname (str): name that this directory reference expands to (this is not checked!)
+    """
+    def __init__(self, archive_path, dirname):
+        self.archive_path = archive_path
+        self.dirname = dirname
+
+    def put(self, destination):
+        """ Copy the referenced directory to this path
+
+        Note:
+            This ignores anything not in the desired directory, given by ``self.dirname``.
+
+        Args:
+            destination (str): path to put this directory (which must NOT already exist)
+
+        References:
+            https://stackoverflow.com/a/8261083/1958900
+        """
+        target = _get_target_path(destination, self.dirname)
+        valid_paths = (self.dirname, './%s'%self.dirname)
+
+        with tarfile.open(self.archive_path, 'r:*') as tf:
+            members = []
+            for tarinfo in tf:
+                # Get only files under the directory `self.dirname`
+                pathsplit = os.path.split(tarinfo.path)
+                if pathsplit[0] not in valid_paths:
+                    print('WARNING: skipped file "%s" in archive; not in directory "%s"' %
+                          (tarinfo.path, self.dirname))
+                    continue
+                tarinfo.name = os.path.join(*pathsplit[1:])
+                members.append(tarinfo)
+
+            if not members:
+                raise ValueError("No files under path directory '%s' in this tarfile")
+
+            tf.extractall(target, members)
+
+
+class DockerArchive(DirectoryArchive, LazyDockerCopy):
+    """
+    Reference to an archived directory from a docker container.
+
+    Notes:
+     - This is currently a bit of a frankenclass
+     - Because it requires access to a docker daemon, this object is not particularly portable.
+    """
+    def __init__(self, *args, **kwargs):
+        LazyDockerCopy.__init__(self, *args, **kwargs)
+        self.archive_path = None
+
+    def put(self, destination):
+        """ Copy the referenced directory to this path
+
+        Args:
+            destination (str): path to put this directory (which must NOT already exist)
+        """
+        target = _get_target_path(destination, self.basename)
+        if not self._fetched:
+            self._fetch()
+        DirectoryArchive.put(self, target)
+
+    put.__doc__ = DirectoryArchive.put.__doc__
+
+    def _fetch(self):
+        self.archive_path = self._open_tmpfile()
+        stream = self._get_tarstream()
+        shutil.copyfileobj(stream, self.tmpfile)
+        stream.close()
+        self.tmpfile.close()

--- a/pyccc/files/directory.py
+++ b/pyccc/files/directory.py
@@ -16,34 +16,7 @@ import tarfile
 import shutil
 
 from .remotefiles import LazyDockerCopy
-from .. import utils
-
-
-def _get_target_path(destination, origname):
-    """ Implements the directory/path semantics of linux mv/cp etc.
-
-    Examples:
-        >>> import os
-        >>> os.makedirs('./a')
-        >>> _get_target_path('./a', '/tmp/myfile')
-        './myfile'
-        >>> _get_target_path('./a/b', '/tmp/myfile')
-        './a/b'
-
-    Raises:
-        OSError: if neither destination NOR destination's parent exists OR it already exists
-    """
-    if os.path.exists(destination):
-        if not os.path.isdir(destination):
-            raise OSError('Cannot write to requested destination %s - file exists' % destination)
-        return os.path.join(destination, os.path.basename(origname))
-    else:
-        destdir = os.path.abspath(os.path.join(destination, os.path.pardir))
-        if not os.path.isdir(destdir):
-            raise OSError(
-                    'Cannot write to requested destination %s - parent directory does not exist' %
-                    destination)
-        return os.path.join(destination)
+from . import get_target_path
 
 
 class DirectoryReference(object):
@@ -69,7 +42,7 @@ class LocalDirectoryReference(DirectoryReference):
         Args:
             destination (str): path to put this directory
         """
-        target = _get_target_path(destination, self.localpath)
+        target = get_target_path(destination, self.localpath)
         shutil.copytree(self.localpath, target)
 
 
@@ -99,8 +72,8 @@ class DirectoryArchive(DirectoryReference):
         References:
             https://stackoverflow.com/a/8261083/1958900
         """
-        target = _get_target_path(destination, self.dirname)
-        valid_paths = (self.dirname, './%s'%self.dirname)
+        target = get_target_path(destination, self.dirname)
+        valid_paths = (self.dirname, './%s' % self.dirname)
 
         with tarfile.open(self.archive_path, 'r:*') as tf:
             members = []

--- a/pyccc/files/localfiles.py
+++ b/pyccc/files/localfiles.py
@@ -105,14 +105,15 @@ class CachedFile(LocalFile):
         self.localpath = self._open_tmpfile()
         filecontainer.put(self.localpath)
 
-    def _open_tmpfile(self):
+    def _open_tmpfile(self, **kwargs):
         """
         Open a temporary, unique file in CACHEDIR (/tmp/cyborgcache) by default.
         Leave it open, assign file handle to self.tmpfile
+
+        **kwargs are passed to tempfile.NamedTemporaryFile
         """
-        tmpfile = get_tempfile()
-        path = tmpfile.name
-        self.tmpfile = tmpfile
+        self.tmpfile = get_tempfile(**kwargs)
+        path = self.tmpfile.name
         return path
 
     def __str__(self):

--- a/pyccc/files/localfiles.py
+++ b/pyccc/files/localfiles.py
@@ -21,7 +21,7 @@ import os
 import shutil
 import socket
 
-from . import BytesContainer, StringContainer, get_tempfile
+from . import BytesContainer, StringContainer, get_tempfile, get_target_path
 
 
 class FileContainer(BytesContainer):
@@ -71,10 +71,11 @@ class LocalFile(FileContainer):
         self.encoded_with = encoded_with
 
     def put(self, filename, encoding=None):
+        target = get_target_path(filename, self.source)
         if encoding is not None:
             raise ValueError('Cannot encode as %s - this file is already encoded')
-        shutil.copy(self.localpath, filename)
-        return LocalFile(filename)
+        shutil.copy(self.localpath, target)
+        return LocalFile(target)
 
     def open(self, mode='r', encoding=None):
         """Return file-like object (actually opens the file for this class)"""

--- a/pyccc/job.py
+++ b/pyccc/job.py
@@ -245,6 +245,18 @@ class Job(object):
         if filename: return self._output_files[filename]
         else: return self._output_files
 
+    def get_directory(self, path):
+        """
+        Get a reference to the directory at the specified path
+
+        Note:
+            This function will succeed even if the specified path
+            does not exist, as it just generates a reference. You won't
+            encounter an exception until you actually try to access the
+            non-existent file
+        """
+        return self.engine.get_directory(self, path)
+
     def glob_output(self, pattern):
         """ Return dict of all files that match the glob pattern
         """

--- a/pyccc/tests/requirements.txt
+++ b/pyccc/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-xdist
+pytest-localserver

--- a/pyccc/tests/test_dir_refs.py
+++ b/pyccc/tests/test_dir_refs.py
@@ -1,8 +1,11 @@
 import os
 
 import itertools
+from .engine_fixtures import *
+
 import pytest
 import pyccc
+
 
 THISDIR = os.path.dirname(__file__)
 
@@ -40,10 +43,21 @@ def _make_dir_archive(tmpdir, compress):
 @pytest.fixture
 def docker_dir_archive(dir_archive):
     engine = pyccc.Docker()
+    return _get_dir_from_job_on_engine(engine, dir_archive)
+
+
+@pytest.fixture
+def subprocess_dir_reference(dir_archive):
+    engine = pyccc.Subprocess()
+    return _get_dir_from_job_on_engine(engine, dir_archive)
+
+
+def _get_dir_from_job_on_engine(engine, dir_archive):
+    archive_file = pyccc.LocalFile(dir_archive.archive_path)
 
     job = engine.launch(image='alpine',
                         workingdir='/test',
-                        inputs={'/test': dir_archive},
+                        inputs={'/test': archive_file},
                         command='tar xvzf /test/archive.tar')
     job.wait()
     return job.get_directory('/test/data')
@@ -69,3 +83,4 @@ def test_put_directory_reference_with_renaming(request, fixturename, tmpdir, rel
                                                target, ['a', 'b'])
     assert not mismatch
     assert not errors
+

--- a/pyccc/tests/test_dir_refs.py
+++ b/pyccc/tests/test_dir_refs.py
@@ -1,0 +1,71 @@
+import os
+
+import itertools
+import pytest
+import pyccc
+
+THISDIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def localdir():
+    return pyccc.files.LocalDirectoryReference(os.path.join(THISDIR, 'data'))
+
+
+@pytest.fixture
+def dir_archive(tmpdir):
+    return _make_dir_archive(tmpdir, False)
+
+
+@pytest.fixture
+def compressed_dir_archive(tmpdir):
+    return _make_dir_archive(tmpdir, True)
+
+
+def _make_dir_archive(tmpdir, compress):
+    import subprocess
+    tmpdir = str(tmpdir)
+    if compress:
+        fname = os.path.join(tmpdir, 'archive.tar.gz')
+        opts = 'z'
+    else:
+        fname = os.path.join(tmpdir, 'archive.tar')
+        opts = ''
+
+    subprocess.check_call(['tar', 'c%sf' % opts, fname, 'data'],
+                          cwd=THISDIR)
+    return pyccc.files.DirectoryArchive(fname, 'data')
+
+
+@pytest.fixture
+def docker_dir_archive(dir_archive):
+    engine = pyccc.Docker()
+
+    job = engine.launch(image='alpine',
+                        workingdir='/test',
+                        inputs={'/test': dir_archive},
+                        command='tar xvzf /test/archive.tar')
+    job.wait()
+    return job.get_directory('/test/data')
+
+
+@pytest.mark.parametrize(['fixturename', 'reldir'],
+                         itertools.product(['localdir', 'dir_archive',
+                                            'compressed_dir_archive', 'docker_dir_archive'],
+                                           ['', 'mydir']))
+def test_put_directory_reference_with_renaming(request, fixturename, tmpdir, reldir):
+    import filecmp
+    tmpdir = str(tmpdir)
+    destination = os.path.join(tmpdir, reldir)
+    fileref = request.getfixturevalue(fixturename)
+    fileref.put(destination)
+
+    source = os.path.join(THISDIR, 'data')
+    if reldir:
+        target = os.path.join(tmpdir, reldir)
+    else:
+        target = os.path.join(tmpdir, 'data')
+    match, mismatch, errors = filecmp.cmpfiles(source,
+                                               target, ['a', 'b'])
+    assert not mismatch
+    assert not errors

--- a/pyccc/tests/test_file_refs.py
+++ b/pyccc/tests/test_file_refs.py
@@ -118,14 +118,3 @@ def test_containers_are_pickleable(fixture, request):
     newctr = pickle.loads(pickle.dumps(ctr))
     assert newctr.read() == ctr.read()
 
-
-def test_local_directory_reference(tmpdir):
-    import filecmp
-    tmpdir = str(tmpdir)
-    src = os.path.join(THISDIR, 'data')
-    localdir = pyccc.files.LocalDirectoryReference(src)
-    target = os.path.join(tmpdir, 'data')
-    localdir.put(target)
-    match, mismatch, errors = filecmp.cmpfiles(src, target, ['a', 'b'])
-    assert not mismatch
-    assert not errors

--- a/pyccc/utils.py
+++ b/pyccc/utils.py
@@ -45,9 +45,8 @@ def wget(url):
     """
     Download the page into a string
     """
-    import urllib.request, urllib.error, urllib.parse
+    import urllib.parse
     request = urllib.request.urlopen(url)
-    ":type: urllib2.req"
     filestring = request.read()
     return filestring
 


### PR DESCRIPTION
Pull directories out of stopped containers (and maybe even running ones, although you probably shouldn't)

Add classes to handle archived directories.

`reference.put([path])` now copies the referenced file/directory to [path]/[basename]